### PR TITLE
Allow only one stream-number in TASK argument.

### DIFF
--- a/asynchronous_tasks.md
+++ b/asynchronous_tasks.md
@@ -440,7 +440,7 @@ be reused.  A Fortran `TASK` region begins with `LOCALITY` statements
 such as the following:
 
 ```fortran
-TASK [(stream-number[,stream-number]...)]
+TASK [(stream-number)]
   LOCALITY(SHARED) :: X(:) ! shared but conflicting accesses are prohibited
   LOCALITY(LOCAL_INIT) :: IBEGIN, IEND, IX
   REAL :: A


### PR DESCRIPTION
Fixes #2 